### PR TITLE
fix: Can't delete category

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -60,7 +60,7 @@ Redmine::Plugin.register :redmine_knowledgebase do
     }
     permission :manage_article_categories, {
       :knowledgebase => :index,
-      :categories    => [:index, :show, :new, :create, :edit, :update, :delete]
+      :categories    => [:index, :show, :new, :create, :edit, :update, :destroy]
     }
   end
   


### PR DESCRIPTION
add ’Manage article categories' permission to user, but can't delete category.
