### PR TITLE
update gemfile source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'acts-as-taggable-on', '~> 2.3.1'
 gem 'ya2yaml'


### PR DESCRIPTION
This prevents 'The source :rubygems is deprecated because HTTP requests are insecure' when bundling.
