### PR TITLE
 Replace :rubygems in Gemfile with 'https://rubygems.org'.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'acts-as-taggable-on', '~> 2.3.1'
 gem 'ya2yaml'


### PR DESCRIPTION
Solves the following bundler warning:

The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
