### PR TITLE
Add default summary_limit if it is blank

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -18,6 +18,7 @@ class ArticlesController < ApplicationController
 
   def index
     summary_limit = redmine_knowledgebase_settings_value(:summary_limit)
+    summary_limit = 25 if summary_limit.blank?
 
     @total_categories = @project.categories.count
     @total_articles = @project.articles.count


### PR DESCRIPTION
Per default, summary_limit is empty which will cause a 500 Error in Redmine.

This option will prevent this, even if a User accidentally removes this setting.
