### PR TITLE
Article/Category link helper uses assigned project ids instead of global one

### DIFF
--- a/app/helpers/knowledgebase_link_helper.rb
+++ b/app/helpers/knowledgebase_link_helper.rb
@@ -1,15 +1,15 @@
 module KnowledgebaseLinkHelper
 
   def link_to_article(article)
-    link_to l(:label_kb_link, :kb_id => article.id.to_s), article_path(@project, article.id), :title => article.title
+    link_to l(:label_kb_link, :kb_id => article.id.to_s), article_path(article.project, article.id), :title => article.title
   end
 
   def link_to_article_with_title(article)
-    link_to "#{l(:label_kb_link, :kb_id => article.id.to_s)}: #{article.title}", article_path(@project, article.id)
+    link_to "#{l(:label_kb_link, :kb_id => article.id.to_s)}: #{article.title}", article_path(article.project, article.id)
   end
 
   def link_to_category_with_title(category)
-    link_to category.title, category_path(@project, category.id)
+    link_to category.title, category_path(category.project, category.id)
   end
 
 end


### PR DESCRIPTION
Article IDs are unique thats why macros may take just only the article id. 

But when the macros is called from within the "wrong" context (main page of redmine, other project) the link generation may fail due missing @project variable or pointing to a wrong project.

So using the assigned project id of article / category is better I think.
