### PR TITLE
Fixes cross-project access of articles and categories

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -8,8 +8,8 @@ class ArticlesController < ApplicationController
   helper :watchers
   include WatchersHelper
 
-  before_filter :get_article, :only => [:add_attachment, :show, :edit, :update, :add_comment, :destroy, :destroy_comment, :diff, :revert, :version]
   before_filter :find_project_by_project_id, :authorize
+  before_filter :get_article, :only => [:add_attachment, :show, :edit, :update, :add_comment, :destroy, :destroy_comment, :diff, :revert, :version]
 
   rescue_from ActionView::MissingTemplate, :with => :force_404
   rescue_from ActiveRecord::RecordNotFound, :with => :force_404
@@ -196,7 +196,7 @@ private
   end
 
   def get_article
-    @article = KbArticle.where(:id => params[:id]).first
+    @article = @project.articles.find(params[:id])
   end
 
   def force_404

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -8,10 +8,12 @@ class CategoriesController < ApplicationController
   include WatchersHelper
 
   before_filter :find_project_by_project_id, :authorize
+  before_filter :get_category, :only => [:show, :edit, :update, :destroy]
   accept_rss_auth :show
+
+  rescue_from ActiveRecord::RecordNotFound, :with => :force_404
   
   def show
-    @category = KbCategory.find(params[:id])
     @articles = @category.articles.order("#{sort_column} #{sort_direction}")
     @categories = @project.categories.where(:parent_id => nil)
     
@@ -46,14 +48,12 @@ class CategoriesController < ApplicationController
   end
 
   def edit
-    @category = KbCategory.find(params[:id])
     @parent_id = @category.parent_id
     @categories=@project.categories.find(:all)
   end
 
   def destroy
-    @category = KbCategory.find(params[:id])
-	@categories=@project.categories.find(:all)
+	  @categories=@project.categories.find(:all)
     if @category.articles.size == 0
 	  @category.destroy
       flash[:notice] = l(:label_category_deleted)
@@ -66,7 +66,6 @@ class CategoriesController < ApplicationController
   end
 
   def update
-    @category = KbCategory.find(params[:id])
     if params[:root_category] == "yes"
       @category.parent_id = nil
     else
@@ -81,4 +80,15 @@ class CategoriesController < ApplicationController
     end
   end
 
+#######
+private
+#######
+  
+  def get_category
+    @category = @project.categories.find(params[:id])
+  end
+
+  def force_404
+    render_404
+  end
 end


### PR DESCRIPTION
This commit fixes a security issue where a user can access articles and categories from other projects by changing the id number at the end of the resource URL. 

Example:
- User is a member of project **'general'** which has a KB article with ID **'1'** (user is allowed to read articles)
- User is not a member of project **'secret'** which has an article with ID **'2'**
- Gain access to **secret**'s article via this url: http://_host_/redmine/projects/**general**/knowledgebase/articles/**2**
- Similar behaviour for categories

After fix behaviour:
- Return a 404 on such a request
