### PR TITLE
Update knowledgebase_helper.rb

### DIFF
--- a/app/helpers/knowledgebase_helper.rb
+++ b/app/helpers/knowledgebase_helper.rb
@@ -17,7 +17,7 @@ module KnowledgebaseHelper
     when "popular"
       l(:label_summary_popular_articles,
         :count => article.view_count,
-        :created => article.created_at.to_formatted_s(:rfc822))
+        :created => article.created_at.to_date.to_formatted_s(:rfc822))
     when "toprated"
       l(:label_summary_toprated_articles,
         :rating_avg => article.rating_average.to_s,
@@ -105,7 +105,7 @@ module KnowledgebaseHelper
 
   def create_preview_link
     v = Redmine::VERSION.to_a
-    if v[0] == 2 && v[1] <= 1
+    if v[0] == 2 && v[1] <= 1 && v[2] <= 0
       link_to_remote l(:label_preview), 
                      { :url => { :controller => 'articles', :action => 'preview' }, 
                        :method => 'post', 


### PR DESCRIPTION
Line 20: the date (24 Feb 2014)  is more concise than the complete TimeStamp (Mon, 24 Feb 2014 23:21:17 +0000) for this section. This is a personal suggestion. 

Line 106: Redmine 2.1.1 moved to Rails 3, so there is no link_to_remote We must test for the 3rd digit not only 2.1
