### PR TITLE
Resolve broken search issue on Redmine 3.X

### DIFF
--- a/app/models/kb_article.rb
+++ b/app/models/kb_article.rb
@@ -27,7 +27,7 @@ class KbArticle < ActiveRecord::Base
 
   acts_as_searchable :columns => [ "#{table_name}.title", "#{table_name}.content"],
                      :scope => preload(:project),
-                     :date_column => "#{table_name}.created_at"
+                     :date_column => "created_at"
 
   acts_as_event :title => Proc.new {|o| status = (o.new_status ? "(#{l(:label_new_article)})" : nil ); "#{status} #{l(:label_title_articles)} ##{o.id} - #{o.title}" },
                 :description => :content,


### PR DESCRIPTION
Redmine 3.X search is broken. This simple PR resolves the issue.

Tested with :
* Redmine 3.0.4
* MySQL adapter only.