### PR TITLE
CSS: Moves label_overview out of the splitcontentleft class

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -18,8 +18,8 @@
   
 <% else %>
   <% if User.current.allowed_to?(:view_kb_articles, @project) %>
+    <h2><%=l(:label_overview)%></h2>
     <div class="splitcontentleft">
-        <h2><%=l(:label_overview)%></h2>
         <div class="articles box">
         <h3><%= l(:title_overview_summary) %></h3>
         <ul>


### PR DESCRIPTION
This makes the Overview h2 part of the default content, instead of part of the splitcontentleft class.  Plays nicer with Pixel-Cookers.

Before:
![kb-before](https://cloud.githubusercontent.com/assets/1377378/11939807/6398321e-a7d9-11e5-88ac-ce5813c1ecfd.jpg)

After:
![kb-after](https://cloud.githubusercontent.com/assets/1377378/11939812/679a2340-a7d9-11e5-948d-5deb784f1c6f.jpg)
