### PR TITLE
Check access permissions to disallow access using direct links

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,11 +1,13 @@
 <% html_title l(:knowledgebase_title) %>
 
 <div class="contextual">
+<% if User.current.allowed_to?(:view_kb_articles, @project) %>
   <%= render :partial => "categories/jump_box" %>
   <%= link_to_if_authorized l(:title_create_category), { :controller => 'categories', :action => 'new', :project_id => @project}, :class => 'icon icon-add' %>
   <% if @project.categories.length > 0 %>	
     <%= link_to_if_authorized l(:title_create_article), { :controller => 'articles', :action => 'new', :project_id => @project}, :class => 'icon icon-add' %>
   <% end %>
+<% end %>
 </div>
 
 <% if @project.categories.count == 0 %>
@@ -53,16 +55,18 @@
         <% end %>
     </div>
     
-    <% content_for :sidebar do %>
-            <h3><%= l(:title_browse_by_category) %></h3>
-            <%= render :partial => "categories/tree" %>
-            </br>
-        <div id="taglist">
-            <h3><%= l(:title_browse_by_tags) %></h3>
-            <% tag_cloud(@tags, ['tag-x-small', 'tag-small', 'tag-medium', 'tag-large', 'tag-x-large']) do |tag, css_class| %>
-            <%= link_to(tag.name, {:controller => 'articles', :action => :tagged, :id => tag.name }, :class => "tag #{css_class}") %>
-            <% end %>
-        </div>
+    <% if User.current.allowed_to?(:view_kb_articles, @project) %>
+        <% content_for :sidebar do %>
+                <h3><%= l(:title_browse_by_category) %></h3>
+                <%= render :partial => "categories/tree" %>
+                </br>
+            <div id="taglist">
+                <h3><%= l(:title_browse_by_tags) %></h3>
+                <% tag_cloud(@tags, ['tag-x-small', 'tag-small', 'tag-medium', 'tag-large', 'tag-x-large']) do |tag, css_class| %>
+                <%= link_to(tag.name, {:controller => 'articles', :action => :tagged, :id => tag.name }, :class => "tag #{css_class}") %>
+                <% end %>
+            </div>
+        <% end %>
     <% end %>
   <% else %>
      <p class="nodata"><%=l(:message_no_permissions)%></p>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -7,9 +7,12 @@
 <% end %>
 
 <div class="contextual">
+<% if User.current.allowed_to?(:view_kb_articles, @project) %>
   <%= render :partial => "categories/jump_box" %>
+<% end %>
 </div>
 
+<% if User.current.allowed_to?(:view_kb_articles, @project) %>
 <% content_for :sidebar do %>
 	<ul id="options">
 		<li><%= link_to_if_authorized l(:label_edit_article), { :controller => 'articles', :action => 'edit', :id => @article.id, :project_id => @project}, :class => 'icon icon-edit' %></li>
@@ -52,3 +55,4 @@
 <% end %>
 
 <%= render_tabs article_tabs %>
+<% end %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,7 +1,9 @@
 <% html_title @category.title %>
 
 <div class="contextual">
+<% if User.current.allowed_to?(:view_kb_articles, @project) %>
   <%= render :partial => "categories/jump_box" %>
+<% end %>
 </div>
 
 <p id="category-crumbs" class="breadcrumb">
@@ -12,6 +14,7 @@
 	<% end %>
 </p>
 
+<% if User.current.allowed_to?(:view_kb_articles, @project) %>
 <h2><%= @category.title %></h2>
 
 <% content_for :sidebar do %>
@@ -47,6 +50,7 @@
 
 <% other_formats_links do |f| %>
   <%= f.link_to 'Atom', :url => { :key => User.current.rss_key } %>
+<% end %>
 <% end %>
 
 <% content_for :header_tags do %>


### PR DESCRIPTION
User without access to the articles can view them using direct links or find out current categories.
