### PR TITLE
fix: category page error when article's author account deleted

### DIFF
--- a/app/views/articles/_list_table.html.erb
+++ b/app/views/articles/_list_table.html.erb
@@ -50,12 +50,12 @@
       <td class="rating"><% rating = article.rating_average.to_i %><%= rating != 0 ? "#{rating} / 5" : "-" %></td>
 
       <% unless @author_id %>
-        <td class="author">        
-	  <%= link_to article.author.name, { :controller => 'articles', 
+      <td class="author">
+        <%= article.author ? (link_to article.author.name, { :controller => 'articles', 
           :action => 'authored', 
           :author_id => article.author.id, 
-          :project_id => @project} %> 
-	</td>
+          :project_id => @project}): l(:label_user_anonymous) %> 
+      </td>
       <% end %>
 
       <td class="created_at"><%= time_ago_in_words article.created_at %> ago</td>


### PR DESCRIPTION
Before:
When visiting a category page, if there's any article whose author's account is deleted, the page returns 500 error.

After:
Deleted author name is diplayed with the anonymous user label.