### PR TITLE
Quickfix, replaces thumbnail_url with polymorphic_url

### DIFF
--- a/app/helpers/knowledgebase_helper.rb
+++ b/app/helpers/knowledgebase_helper.rb
@@ -181,7 +181,7 @@ module KnowledgebaseHelper
     thumb = get_article_thumbnail( article )
 
     if thumb
-      return "#{Setting.protocol}://#{Setting.host_name}#{thumbnail_path(thumb)}"
+      return polymorphic_url(thumb, :host => Setting.host_name, :protocol => Setting.protocol)
     else
       return ''
     end


### PR DESCRIPTION
As described in https://github.com/rails/rails/pull/15840 - `*_path` methods should not be allowed within Mailer actions. 

The original code is in fact constructing an absolute URL, but is doing so by making using of a `*_path` method.
This is fine for web and data views, but not for Mailer views.

Rails' `polymorphic_url` exists since Version 2 and its syntax experienced no changes, so i assume it should be a backward compatible replacement.